### PR TITLE
Add full-week workouts with instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,95 @@
             box-shadow: 0 2px 8px rgba(0,0,0,0.1);
         }
 
+        .weekly-history {
+            background: white;
+            padding: 2rem;
+            border-radius: 12px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            margin-top: 2rem;
+        }
+
+        .weekly-history h2 {
+            margin-bottom: 1rem;
+            font-size: 1.8rem;
+        }
+
+        .weekly-history-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .weekly-history-item {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.75rem 1rem;
+            padding: 1rem;
+            border: 1px solid #e5e7eb;
+            border-radius: 10px;
+            background: #f9fafb;
+            transition: border-color 0.2s ease, background 0.2s ease;
+        }
+
+        .weekly-history-item.current {
+            border-color: #2563eb;
+            background: #eff6ff;
+        }
+
+        .weekly-history-item.complete {
+            border-color: #10b981;
+            background: #ecfdf5;
+        }
+
+        .weekly-history-dates {
+            font-weight: 600;
+            font-size: 1rem;
+            color: #1f2937;
+        }
+
+        .weekly-history-progress {
+            flex: 1 1 220px;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .weekly-history-bar {
+            flex: 1;
+            height: 8px;
+            background: #e5e7eb;
+            border-radius: 999px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .weekly-history-bar-fill {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            background: #2563eb;
+            border-radius: 999px;
+            transition: width 0.3s ease;
+        }
+
+        .weekly-history-count {
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .weekly-history-status {
+            color: #6b7280;
+            font-size: 0.9rem;
+        }
+
+        .weekly-history-empty {
+            color: #6b7280;
+            font-size: 0.95rem;
+        }
+
         .achievement-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
@@ -334,6 +423,13 @@
         <div class="workout-schedule">
             <h2 style="margin-bottom: 1.5rem; font-size: 1.8rem;">Weekly Training Schedule</h2>
             <div id="workoutCards"></div>
+        </div>
+
+        <div class="weekly-history">
+            <h2>📅 Weekly Progress</h2>
+            <div id="weeklyHistory" class="weekly-history-list">
+                <div class="weekly-history-empty">Complete workouts to start building your weekly history.</div>
+            </div>
         </div>
 
         <div class="achievements">
@@ -767,6 +863,32 @@
             return formatDate(current);
         }
 
+        function formatWeekRangeLabel(weekKey) {
+            if (!weekKey) {
+                return 'Current Week';
+            }
+
+            const start = parseDateKey(weekKey);
+            if (Number.isNaN(start.getTime())) {
+                return `Week of ${weekKey}`;
+            }
+
+            const end = new Date(start);
+            end.setDate(end.getDate() + 6);
+
+            const startYear = start.getFullYear();
+            const endYear = end.getFullYear();
+            const options = { month: 'short', day: 'numeric' };
+            const startLabel = start.toLocaleDateString(undefined, options);
+            const endLabel = end.toLocaleDateString(undefined, options);
+
+            if (startYear === endYear) {
+                return `${startLabel} – ${endLabel}, ${startYear}`;
+            }
+
+            return `${startLabel}, ${startYear} – ${endLabel}, ${endYear}`;
+        }
+
         function addDayToLogs(day, dateKey) {
             if (!dateKey) {
                 return;
@@ -844,6 +966,111 @@
             }
 
             return count;
+        }
+
+        function renderWeeklyHistory() {
+            const container = document.getElementById('weeklyHistory');
+            if (!container) {
+                return;
+            }
+
+            const totalWorkouts = Object.keys(workoutMeta).length;
+            const entries = new Map();
+
+            if (currentWeekKey) {
+                entries.set(currentWeekKey, {
+                    weekKey: currentWeekKey,
+                    workouts: [],
+                    isCurrent: true
+                });
+            }
+
+            Object.entries(weekCompletions).forEach(([weekKey, info]) => {
+                if (!info) {
+                    return;
+                }
+                const workouts = Array.isArray(info.workouts)
+                    ? Array.from(new Set(info.workouts))
+                    : [];
+                if (entries.has(weekKey)) {
+                    const existing = entries.get(weekKey);
+                    existing.workouts = Array.from(new Set([...existing.workouts, ...workouts]));
+                } else {
+                    entries.set(weekKey, {
+                        weekKey,
+                        workouts,
+                        isCurrent: weekKey === currentWeekKey
+                    });
+                }
+            });
+
+            const weeks = Array.from(entries.values())
+                .sort((a, b) => (a.weekKey < b.weekKey ? 1 : -1))
+                .slice(0, 8);
+
+            container.innerHTML = '';
+
+            if (weeks.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'weekly-history-empty';
+                empty.textContent = 'Complete workouts to start building your weekly history.';
+                container.appendChild(empty);
+                return;
+            }
+
+            weeks.forEach(({ weekKey, workouts, isCurrent }) => {
+                const uniqueWorkouts = Array.from(new Set(workouts));
+                const completedCount = uniqueWorkouts.length;
+                const progressPercent = totalWorkouts > 0
+                    ? Math.min(100, (completedCount / totalWorkouts) * 100)
+                    : 0;
+
+                const item = document.createElement('div');
+                item.className = 'weekly-history-item';
+                if (isCurrent) {
+                    item.classList.add('current');
+                }
+                if (totalWorkouts > 0 && completedCount >= totalWorkouts) {
+                    item.classList.add('complete');
+                }
+
+                const label = document.createElement('div');
+                label.className = 'weekly-history-dates';
+                const baseLabel = formatWeekRangeLabel(weekKey);
+                label.textContent = isCurrent ? `${baseLabel} (Current)` : baseLabel;
+
+                const progressWrap = document.createElement('div');
+                progressWrap.className = 'weekly-history-progress';
+
+                const bar = document.createElement('div');
+                bar.className = 'weekly-history-bar';
+
+                const fill = document.createElement('div');
+                fill.className = 'weekly-history-bar-fill';
+                fill.style.width = `${progressPercent}%`;
+                bar.appendChild(fill);
+
+                const count = document.createElement('div');
+                count.className = 'weekly-history-count';
+                count.textContent = totalWorkouts > 0
+                    ? `${completedCount}/${totalWorkouts} days`
+                    : `${completedCount} days`;
+
+                progressWrap.append(bar, count);
+
+                const status = document.createElement('div');
+                status.className = 'weekly-history-status';
+                if (totalWorkouts > 0 && completedCount >= totalWorkouts) {
+                    status.textContent = 'Week complete! Fantastic consistency.';
+                } else if (completedCount === 0) {
+                    status.textContent = 'No workouts logged yet.';
+                } else {
+                    status.textContent = 'Keep building momentum!';
+                }
+
+                item.append(label, progressWrap, status);
+                container.appendChild(item);
+            });
         }
         function unlockAchievement(id, message, notify = false) {
             if (!ACHIEVEMENT_DETAILS[id]) {
@@ -1102,6 +1329,7 @@
             updateDisplay();
             evaluateAchievements({ notify: options.notifyAchievements });
             updateAchievementsDisplay();
+            renderWeeklyHistory();
 
             const achievementLabel = document.getElementById('achievementCount');
             if (achievementLabel) {

--- a/index.html
+++ b/index.html
@@ -191,6 +191,30 @@
             font-size: 0.8rem;
             font-weight: bold;
         }
+
+        .workout-instructions {
+            background: #eef2ff;
+            border-left: 4px solid #6366f1;
+            border-radius: 8px;
+            padding: 0.75rem 1rem;
+            margin: 0.75rem 0 1rem;
+            color: #4338ca;
+        }
+
+        .workout-instructions p {
+            font-size: 0.95rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .workout-instructions ul {
+            margin-left: 1.25rem;
+            list-style: disc;
+        }
+
+        .workout-instructions li {
+            font-size: 0.9rem;
+            margin-bottom: 0.35rem;
+        }
         
         .button {
             background: #2563eb;
@@ -329,10 +353,19 @@
                     <div class="progress-fill" id="progress-monday" style="width: 0%"></div>
                 </div>
                 <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
-                    <span id="completion-monday">0% Complete (0/13 exercises)</span>
+                    <span id="completion-monday">0% Complete (0/0 exercises)</span>
                     <span style="float: right; color: #2563eb; font-weight: bold;">
-                        <span id="xp-monday">0</span>/150 XP
+                        <span id="xp-monday">0</span>/<span id="xp-target-monday">0</span> XP
                     </span>
+                </div>
+
+                <div class="workout-instructions">
+                    <p><strong>Instructions:</strong> Build explosive leg power while keeping pristine movement quality.</p>
+                    <ul>
+                        <li>Use a light dynamic warm-up before the first strength set and ease into depth on squats and lunges.</li>
+                        <li>Rest 45-60 seconds between sets and chase controlled tempo rather than speed.</li>
+                        <li>Hold stretches for the full prescribed time and breathe through each range.</li>
+                    </ul>
                 </div>
                 
                 <div class="exercise-list" id="exercises-monday">
@@ -458,11 +491,21 @@
                     <div class="progress-fill" id="progress-tuesday" style="width: 0%"></div>
                 </div>
                 <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
-                    <span id="completion-tuesday">0% Complete (0/13 exercises)</span>
+                    <span id="completion-tuesday">0% Complete (0/0 exercises)</span>
                     <span style="float: right; color: #2563eb; font-weight: bold;">
-                        <span id="xp-tuesday">0</span>/140 XP
+                        <span id="xp-tuesday">0</span>/<span id="xp-target-tuesday">0</span> XP
                     </span>
                 </div>
+
+                <div class="workout-instructions">
+                    <p><strong>Instructions:</strong> Prime the upper body for resilient saves and stay braced through the core.</p>
+                    <ul>
+                        <li>Move smoothly through the mobility pieces before loading resistance moves.</li>
+                        <li>Keep ribs stacked over hips during pressing and plank variations to protect your back.</li>
+                        <li>Cap each set one rep shy of failure so you can finish the session with crisp form.</li>
+                    </ul>
+                </div>
+
                 
                 <div class="exercise-list" id="exercises-tuesday">
                     <div class="exercise-item" onclick="toggleExercise('tuesday', 0)">
@@ -572,7 +615,655 @@
                 </div>
             </div>
 
-            <!-- Add more days here if needed -->
+            <div class="workout-card" data-day="wednesday">
+                <div class="workout-header">
+                    <div class="workout-title">
+                        <span class="workout-emoji">⚡</span>
+                        <div>
+                            <div class="workout-name">Wednesday</div>
+                            <div class="workout-description">Agility & Lateral Quickness</div>
+                        </div>
+                    </div>
+                    <button class="button button-small" onclick="toggleWorkout('wednesday')">Start Workout</button>
+                </div>
+                <div class="progress-bar">
+                    <div class="progress-fill" id="progress-wednesday" style="width: 0%"></div>
+                </div>
+                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
+                    <span id="completion-wednesday">0% Complete (0/0 exercises)</span>
+                    <span style="float: right; color: #2563eb; font-weight: bold;">
+                        <span id="xp-wednesday">0</span>/<span id="xp-target-wednesday">0</span> XP
+                    </span>
+                </div>
+
+                <div class="workout-instructions">
+                    <p><strong>Instructions:</strong> Stay light on your edges and push for fast feet without sacrificing stance.</p>
+                    <ul>
+                        <li>Drive knees over toes during lateral moves and stick the landing before exploding again.</li>
+                        <li>Keep torso tall and eyes forward so you can react quickly like you would in the crease.</li>
+                        <li>Recover with 30-40 seconds of easy movement between explosive intervals.</li>
+                    </ul>
+                </div>
+
+                <div class="exercise-list" id="exercises-wednesday">
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 0)">
+                        <div class="exercise-checkbox">1</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Jump Rope Warm-up</div>
+                            <div class="exercise-reps">3 minutes steady pace</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 1)">
+                        <div class="exercise-checkbox">2</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Lateral Line Hops</div>
+                            <div class="exercise-reps">20 each side × 2 sets</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 2)">
+                        <div class="exercise-checkbox">3</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Agility Ladder In-Out</div>
+                            <div class="exercise-reps">4 rounds down and back</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 3)">
+                        <div class="exercise-checkbox">4</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">T-Drill Shuffle</div>
+                            <div class="exercise-reps">5 patterns, reset tall stance</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 4)">
+                        <div class="exercise-checkbox">5</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Lateral Bounds</div>
+                            <div class="exercise-reps">12 each side × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">30 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 5)">
+                        <div class="exercise-checkbox">6</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Cone Shuffle Patterns</div>
+                            <div class="exercise-reps">5 rounds with quick pivots</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 6)">
+                        <div class="exercise-checkbox">7</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Carioca Steps</div>
+                            <div class="exercise-reps">3 lengths each direction</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 7)">
+                        <div class="exercise-checkbox">8</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Quick Feet to Sprawl</div>
+                            <div class="exercise-reps">12 reps × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 8)">
+                        <div class="exercise-checkbox">9</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Reaction Ball Toss</div>
+                            <div class="exercise-reps">3 rounds × 45 seconds</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 9)">
+                        <div class="exercise-checkbox">10</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Shuttle Sprints</div>
+                            <div class="exercise-reps">6 × 20 meter efforts</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 10)">
+                        <div class="exercise-checkbox">11</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Box Jumps with Stick</div>
+                            <div class="exercise-reps">10 reps × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">30 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('wednesday', 11)">
+                        <div class="exercise-checkbox">12</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Dynamic Cool Down</div>
+                            <div class="exercise-reps">5 minutes easy mobility</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="workout-card" data-day="thursday">
+                <div class="workout-header">
+                    <div class="workout-title">
+                        <span class="workout-emoji">🧘‍♂️</span>
+                        <div>
+                            <div class="workout-name">Thursday</div>
+                            <div class="workout-description">Recovery & Mobility Reset</div>
+                        </div>
+                    </div>
+                    <button class="button button-small" onclick="toggleWorkout('thursday')">Start Workout</button>
+                </div>
+                <div class="progress-bar">
+                    <div class="progress-fill" id="progress-thursday" style="width: 0%"></div>
+                </div>
+                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
+                    <span id="completion-thursday">0% Complete (0/0 exercises)</span>
+                    <span style="float: right; color: #2563eb; font-weight: bold;">
+                        <span id="xp-thursday">0</span>/<span id="xp-target-thursday">0</span> XP
+                    </span>
+                </div>
+
+                <div class="workout-instructions">
+                    <p><strong>Instructions:</strong> Ease tension and refill the tank before the weekend push.</p>
+                    <ul>
+                        <li>Spend extra time on hotspots—foam rolling and stretching should feel restorative, not rushed.</li>
+                        <li>Breathe slowly through each mobility drill and relax shoulders away from ears.</li>
+                        <li>Keep the heart rate low; this is about quality recovery and range of motion.</li>
+                    </ul>
+                </div>
+
+                <div class="exercise-list" id="exercises-thursday">
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 0)">
+                        <div class="exercise-checkbox">1</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Foam Roll Lower Body</div>
+                            <div class="exercise-reps">2 minutes per major muscle group</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 1)">
+                        <div class="exercise-checkbox">2</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Banded Ankle Mobilizations</div>
+                            <div class="exercise-reps">15 rocks each side × 2 sets</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 2)">
+                        <div class="exercise-checkbox">3</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Thoracic Open Book Rotations</div>
+                            <div class="exercise-reps">10 each side × 2 sets</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 3)">
+                        <div class="exercise-checkbox">4</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">World's Greatest Stretch</div>
+                            <div class="exercise-reps">6 each side with pause</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 4)">
+                        <div class="exercise-checkbox">5</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Hamstring Flossing</div>
+                            <div class="exercise-reps">15 reps each leg × 2 sets</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 5)">
+                        <div class="exercise-checkbox">6</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Adductor Rock Back Stretch</div>
+                            <div class="exercise-reps">45 seconds each side × 2 sets</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 6)">
+                        <div class="exercise-checkbox">7</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Half-Kneeling Hip Flexor Stretch</div>
+                            <div class="exercise-reps">60 seconds each side × 2 sets</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 7)">
+                        <div class="exercise-checkbox">8</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Prone Press-Ups</div>
+                            <div class="exercise-reps">10 slow reps × 2 sets</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 8)">
+                        <div class="exercise-checkbox">9</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Child's Pose Breathing</div>
+                            <div class="exercise-reps">3 rounds × 5 deep breaths</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 9)">
+                        <div class="exercise-checkbox">10</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Supine Spinal Twist</div>
+                            <div class="exercise-reps">45 seconds each side</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 10)">
+                        <div class="exercise-checkbox">11</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Diaphragmatic Breathing</div>
+                            <div class="exercise-reps">4 minutes nasal breathing</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('thursday', 11)">
+                        <div class="exercise-checkbox">12</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Contrast Shower or Ice Bath</div>
+                            <div class="exercise-reps">5-7 minutes alternated</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="workout-card" data-day="friday">
+                <div class="workout-header">
+                    <div class="workout-title">
+                        <span class="workout-emoji">🏋️‍♂️</span>
+                        <div>
+                            <div class="workout-name">Friday</div>
+                            <div class="workout-description">Strength & Power Finish</div>
+                        </div>
+                    </div>
+                    <button class="button button-small" onclick="toggleWorkout('friday')">Start Workout</button>
+                </div>
+                <div class="progress-bar">
+                    <div class="progress-fill" id="progress-friday" style="width: 0%"></div>
+                </div>
+                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
+                    <span id="completion-friday">0% Complete (0/0 exercises)</span>
+                    <span style="float: right; color: #2563eb; font-weight: bold;">
+                        <span id="xp-friday">0</span>/<span id="xp-target-friday">0</span> XP
+                    </span>
+                </div>
+
+                <div class="workout-instructions">
+                    <p><strong>Instructions:</strong> Attack the lifts with intent and stick every landing like a highlight reel save.</p>
+                    <ul>
+                        <li>Complete a thorough dynamic warm-up before loading heavier movements.</li>
+                        <li>Use powerful concentric drives and a two-count controlled lowering phase.</li>
+                        <li>Rest 90 seconds between big lifts and 60 seconds on accessory work.</li>
+                    </ul>
+                </div>
+
+                <div class="exercise-list" id="exercises-friday">
+                    <div class="exercise-item" onclick="toggleExercise('friday', 0)">
+                        <div class="exercise-checkbox">1</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Dynamic Warm-up Flow</div>
+                            <div class="exercise-reps">5 minutes of movement prep</div>
+                        </div>
+                        <div class="exercise-xp">10 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 1)">
+                        <div class="exercise-checkbox">2</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Medicine Ball Slams</div>
+                            <div class="exercise-reps">10 reps × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 2)">
+                        <div class="exercise-checkbox">3</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Kettlebell Swings</div>
+                            <div class="exercise-reps">15 reps × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 3)">
+                        <div class="exercise-checkbox">4</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Trap Bar Deadlift</div>
+                            <div class="exercise-reps">5 reps × 4 sets (heavy)</div>
+                        </div>
+                        <div class="exercise-xp">30 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 4)">
+                        <div class="exercise-checkbox">5</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Rear Foot Elevated Split Squat</div>
+                            <div class="exercise-reps">8 each leg × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 5)">
+                        <div class="exercise-checkbox">6</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Single-Leg Box Squat</div>
+                            <div class="exercise-reps">8 each leg × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 6)">
+                        <div class="exercise-checkbox">7</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Bulgarian Split Squat Jumps</div>
+                            <div class="exercise-reps">6 each leg × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">30 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 7)">
+                        <div class="exercise-checkbox">8</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Standing Broad Jumps</div>
+                            <div class="exercise-reps">6 jumps × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 8)">
+                        <div class="exercise-checkbox">9</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Push Press</div>
+                            <div class="exercise-reps">6 reps × 4 sets</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 9)">
+                        <div class="exercise-checkbox">10</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Farmer's Carry</div>
+                            <div class="exercise-reps">40 meters × 3 trips</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 10)">
+                        <div class="exercise-checkbox">11</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Ab Wheel or TRX Rollouts</div>
+                            <div class="exercise-reps">10 reps × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('friday', 11)">
+                        <div class="exercise-checkbox">12</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Cooldown Stretch Series</div>
+                            <div class="exercise-reps">5 minutes focused mobility</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="workout-card" data-day="saturday">
+                <div class="workout-header">
+                    <div class="workout-title">
+                        <span class="workout-emoji">🔥</span>
+                        <div>
+                            <div class="workout-name">Saturday</div>
+                            <div class="workout-description">Conditioning & Crease Simulation</div>
+                        </div>
+                    </div>
+                    <button class="button button-small" onclick="toggleWorkout('saturday')">Start Workout</button>
+                </div>
+                <div class="progress-bar">
+                    <div class="progress-fill" id="progress-saturday" style="width: 0%"></div>
+                </div>
+                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
+                    <span id="completion-saturday">0% Complete (0/0 exercises)</span>
+                    <span style="float: right; color: #2563eb; font-weight: bold;">
+                        <span id="xp-saturday">0</span>/<span id="xp-target-saturday">0</span> XP
+                    </span>
+                </div>
+
+                <div class="workout-instructions">
+                    <p><strong>Instructions:</strong> Mimic the chaos of a game—quick bursts, sharp stops, and rapid recoveries.</p>
+                    <ul>
+                        <li>Keep movements crisp with athletic posture; imagine tracking the puck during every change of direction.</li>
+                        <li>Push intensity on intervals, then reset breathing through the nose during rest.</li>
+                        <li>Finish with mobility and visualization so you walk away energized, not crushed.</li>
+                    </ul>
+                </div>
+
+                <div class="exercise-list" id="exercises-saturday">
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 0)">
+                        <div class="exercise-checkbox">1</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Dynamic Skater Warm-up</div>
+                            <div class="exercise-reps">5 minutes flowing drills</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 1)">
+                        <div class="exercise-checkbox">2</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Lateral Shuffle Intervals</div>
+                            <div class="exercise-reps">6 rounds × 30 seconds on/30 seconds off</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 2)">
+                        <div class="exercise-checkbox">3</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Suicide Sprints</div>
+                            <div class="exercise-reps">4 sets through 5 markers</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 3)">
+                        <div class="exercise-checkbox">4</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Bike Sprint Intervals</div>
+                            <div class="exercise-reps">8 rounds × 15 seconds all-out</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 4)">
+                        <div class="exercise-checkbox">5</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Battle Rope Slams</div>
+                            <div class="exercise-reps">4 rounds × 30 seconds</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 5)">
+                        <div class="exercise-checkbox">6</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Bear Crawl Patterns</div>
+                            <div class="exercise-reps">3 rounds forward/backward</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 6)">
+                        <div class="exercise-checkbox">7</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Slide Board Lateral Drives</div>
+                            <div class="exercise-reps">4 rounds × 45 seconds</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 7)">
+                        <div class="exercise-checkbox">8</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Burpee to Lateral Jump</div>
+                            <div class="exercise-reps">12 reps × 3 sets</div>
+                        </div>
+                        <div class="exercise-xp">25 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 8)">
+                        <div class="exercise-checkbox">9</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Mountain Climbers</div>
+                            <div class="exercise-reps">3 rounds × 45 seconds</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 9)">
+                        <div class="exercise-checkbox">10</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Jump Rope Cooldown</div>
+                            <div class="exercise-reps">4 minutes light pace</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 10)">
+                        <div class="exercise-checkbox">11</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Lower Body Mobility Flow</div>
+                            <div class="exercise-reps">5 minutes focus on hips</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('saturday', 11)">
+                        <div class="exercise-checkbox">12</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Performance Visualization</div>
+                            <div class="exercise-reps">5 minutes eyes closed</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="workout-card" data-day="sunday">
+                <div class="workout-header">
+                    <div class="workout-title">
+                        <span class="workout-emoji">🌿</span>
+                        <div>
+                            <div class="workout-name">Sunday</div>
+                            <div class="workout-description">Stability & Mindfulness</div>
+                        </div>
+                    </div>
+                    <button class="button button-small" onclick="toggleWorkout('sunday')">Start Workout</button>
+                </div>
+                <div class="progress-bar">
+                    <div class="progress-fill" id="progress-sunday" style="width: 0%"></div>
+                </div>
+                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
+                    <span id="completion-sunday">0% Complete (0/0 exercises)</span>
+                    <span style="float: right; color: #2563eb; font-weight: bold;">
+                        <span id="xp-sunday">0</span>/<span id="xp-target-sunday">0</span> XP
+                    </span>
+                </div>
+
+                <div class="workout-instructions">
+                    <p><strong>Instructions:</strong> Shift into active recovery and set the tone for next week.</p>
+                    <ul>
+                        <li>Move intentionally through balance work—quality time on each leg beats racing the clock.</li>
+                        <li>Focus on controlled breathing to reset the nervous system.</li>
+                        <li>Finish with reflection so you start Monday prepared and confident.</li>
+                    </ul>
+                </div>
+
+                <div class="exercise-list" id="exercises-sunday">
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 0)">
+                        <div class="exercise-checkbox">1</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Gentle Mobility Warm-up</div>
+                            <div class="exercise-reps">5 minutes easy range of motion</div>
+                        </div>
+                        <div class="exercise-xp">10 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 1)">
+                        <div class="exercise-checkbox">2</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Yoga Sun Salutations</div>
+                            <div class="exercise-reps">5 slow rounds</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 2)">
+                        <div class="exercise-checkbox">3</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Balance Board Holds</div>
+                            <div class="exercise-reps">3 rounds × 45 seconds</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 3)">
+                        <div class="exercise-checkbox">4</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Single-Leg Reach Matrix</div>
+                            <div class="exercise-reps">6 each direction per leg</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 4)">
+                        <div class="exercise-checkbox">5</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Dead Bug Iso Hold</div>
+                            <div class="exercise-reps">3 rounds × 30 seconds</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 5)">
+                        <div class="exercise-checkbox">6</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Side Plank with Leg Lift</div>
+                            <div class="exercise-reps">3 rounds × 30 seconds each side</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 6)">
+                        <div class="exercise-checkbox">7</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Mini-Band Glute Activation</div>
+                            <div class="exercise-reps">15 reps each move × 2 sets</div>
+                        </div>
+                        <div class="exercise-xp">20 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 7)">
+                        <div class="exercise-checkbox">8</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Hip Capsule Stretch</div>
+                            <div class="exercise-reps">45 seconds each side</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 8)">
+                        <div class="exercise-checkbox">9</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Seated Hamstring Stretch</div>
+                            <div class="exercise-reps">60 seconds each leg</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 9)">
+                        <div class="exercise-checkbox">10</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Box Breathing</div>
+                            <div class="exercise-reps">6 rounds of 4-4-4-4</div>
+                        </div>
+                        <div class="exercise-xp">15 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 10)">
+                        <div class="exercise-checkbox">11</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Performance Journal Reflection</div>
+                            <div class="exercise-reps">10 minutes writing wins & lessons</div>
+                        </div>
+                        <div class="exercise-xp">10 XP</div>
+                    </div>
+                    <div class="exercise-item" onclick="toggleExercise('sunday', 11)">
+                        <div class="exercise-checkbox">12</div>
+                        <div class="exercise-info">
+                            <div class="exercise-name">Plan Upcoming Week</div>
+                            <div class="exercise-reps">Review schedule & goals</div>
+                        </div>
+                        <div class="exercise-xp">10 XP</div>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- Achievements -->
@@ -612,45 +1303,326 @@
     </div>
 
     <script>
-        // Simple fitness app functionality
+        const workoutMeta = {};
+        const ACHIEVEMENT_DETAILS = {
+            first: { elementId: 'achievement-first', message: '🥇 Achievement Unlocked: First Steps!' },
+            week: { elementId: 'achievement-week', message: '⚔️ Achievement Unlocked: Week Warrior!' },
+            streak: { elementId: 'achievement-streak', message: '🔥 Achievement Unlocked: Streak Master!' },
+            goalie: { elementId: 'achievement-goalie', message: '🥅 Achievement Unlocked: Goalie God!' }
+        };
+
         let exerciseData = {};
         let totalXP = 0;
         let level = 1;
         let streak = 0;
         let achievements = [];
+        let dayCompletion = {};
+        let activityLog = {};
+        let weekCompletions = {};
+        let currentWeekKey = null;
 
-        // Load saved data
-        function loadData() {
-            const saved = localStorage.getItem('goalieApp');
-            if (saved) {
-                const data = JSON.parse(saved);
-                exerciseData = data.exerciseData || {};
-                totalXP = data.totalXP || 0;
-                level = data.level || 1;
-                streak = data.streak || 0;
-                achievements = data.achievements || [];
-                updateDisplay();
+        function initializeWorkoutMeta() {
+            document.querySelectorAll('.workout-card').forEach(card => {
+                const day = card.dataset.day;
+                if (!day) {
+                    return;
+                }
+                const exerciseItems = card.querySelectorAll('.exercise-item');
+                const totalExercises = exerciseItems.length;
+                const totalXP = Array.from(exerciseItems).reduce((sum, item) => {
+                    const xpElement = item.querySelector('.exercise-xp');
+                    const xpValue = xpElement ? parseInt(xpElement.textContent, 10) : 0;
+                    return sum + (isNaN(xpValue) ? 0 : xpValue);
+                }, 0);
+                workoutMeta[day] = { totalExercises, totalXP };
+
+                const targetSpan = document.getElementById(`xp-target-${day}`);
+                if (targetSpan) {
+                    targetSpan.textContent = totalXP;
+                }
+
+                const completionSpan = document.getElementById(`completion-${day}`);
+                if (completionSpan) {
+                    completionSpan.textContent = `0% Complete (0/${totalExercises} exercises)`;
+                }
+
+                const currentXpSpan = document.getElementById(`xp-${day}`);
+                if (currentXpSpan) {
+                    currentXpSpan.textContent = 0;
+                }
+            });
+        }
+
+        function formatDate(date) {
+            const year = date.getFullYear();
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+            return `${year}-${month}-${day}`;
+        }
+
+        function parseDateKey(key) {
+            const [year, month, day] = key.split('-').map(Number);
+            const parsed = new Date();
+            parsed.setFullYear(year, (month || 1) - 1, day || 1);
+            parsed.setHours(0, 0, 0, 0);
+            return parsed;
+        }
+
+        function getTodayKey() {
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            return formatDate(today);
+        }
+
+        function getWeekKey(date) {
+            const current = new Date(date);
+            current.setHours(0, 0, 0, 0);
+            const day = current.getDay();
+            const diff = day === 0 ? -6 : 1 - day;
+            current.setDate(current.getDate() + diff);
+            return formatDate(current);
+        }
+
+        function addDayToLogs(day, dateKey) {
+            if (!dateKey) {
+                return;
+            }
+            if (!activityLog[dateKey]) {
+                activityLog[dateKey] = { workouts: [] };
+            }
+            if (!activityLog[dateKey].workouts.includes(day)) {
+                activityLog[dateKey].workouts.push(day);
+            }
+
+            const weekKey = getWeekKey(parseDateKey(dateKey));
+            if (!weekCompletions[weekKey]) {
+                weekCompletions[weekKey] = { workouts: [] };
+            }
+            if (!weekCompletions[weekKey].workouts.includes(day)) {
+                weekCompletions[weekKey].workouts.push(day);
             }
         }
 
-        // Save data
+        function removeDayFromLogs(day, dateKey) {
+            if (!dateKey) {
+                return;
+            }
+            const log = activityLog[dateKey];
+            if (log && Array.isArray(log.workouts)) {
+                log.workouts = log.workouts.filter(item => item !== day);
+                if (log.workouts.length === 0) {
+                    delete activityLog[dateKey];
+                }
+            }
+
+            const weekKey = getWeekKey(parseDateKey(dateKey));
+            const week = weekCompletions[weekKey];
+            if (week && Array.isArray(week.workouts)) {
+                week.workouts = week.workouts.filter(item => item !== day);
+                if (week.workouts.length === 0) {
+                    delete weekCompletions[weekKey];
+                }
+            }
+        }
+
+        function syncDayCompletion(day, isComplete) {
+            const current = dayCompletion[day] || { isComplete: false, completionDate: null };
+            if (current.isComplete === isComplete) {
+                return;
+            }
+
+            if (isComplete) {
+                const todayKey = getTodayKey();
+                dayCompletion[day] = { isComplete: true, completionDate: todayKey };
+                addDayToLogs(day, todayKey);
+            } else {
+                if (current.completionDate) {
+                    removeDayFromLogs(day, current.completionDate);
+                }
+                dayCompletion[day] = { isComplete: false, completionDate: null };
+            }
+        }
+
+        function computeStreak(referenceDate = new Date()) {
+            let count = 0;
+            const date = new Date(referenceDate);
+            date.setHours(0, 0, 0, 0);
+
+            while (true) {
+                const key = formatDate(date);
+                const log = activityLog[key];
+                if (log && Array.isArray(log.workouts) && log.workouts.length > 0) {
+                    count += 1;
+                    date.setDate(date.getDate() - 1);
+                } else {
+                    break;
+                }
+            }
+
+            return count;
+        }
+
+        function unlockAchievement(id, message, notify = false) {
+            if (!ACHIEVEMENT_DETAILS[id]) {
+                return;
+            }
+            if (!achievements.includes(id)) {
+                achievements.push(id);
+                if (notify && message) {
+                    alert(message);
+                }
+            }
+        }
+
+        function evaluateAchievements({ notify = false } = {}) {
+            if (streak >= 7) {
+                unlockAchievement('streak', ACHIEVEMENT_DETAILS.streak.message, notify);
+            }
+
+            const totalWorkouts = Object.keys(workoutMeta).length;
+            if (totalWorkouts > 0) {
+                const hasFullWeek = Object.values(weekCompletions).some(week => {
+                    const workouts = Array.isArray(week.workouts) ? Array.from(new Set(week.workouts)) : [];
+                    return workouts.length >= totalWorkouts;
+                });
+                if (hasFullWeek) {
+                    unlockAchievement('week', ACHIEVEMENT_DETAILS.week.message, notify);
+                }
+            }
+
+            if (level >= 10) {
+                unlockAchievement('goalie', ACHIEVEMENT_DETAILS.goalie.message, notify);
+            }
+        }
+
+        function updateAchievementsDisplay() {
+            Object.entries(ACHIEVEMENT_DETAILS).forEach(([id, detail]) => {
+                const element = document.getElementById(detail.elementId);
+                if (!element) {
+                    return;
+                }
+                if (achievements.includes(id)) {
+                    element.classList.add('unlocked');
+                } else {
+                    element.classList.remove('unlocked');
+                }
+            });
+        }
+
+        function loadData() {
+            const saved = localStorage.getItem('goalieApp');
+            const nowWeekKey = getWeekKey(new Date());
+            currentWeekKey = nowWeekKey;
+            if (!saved) {
+                return;
+            }
+            try {
+                const data = JSON.parse(saved);
+                exerciseData = data.exerciseData || {};
+                totalXP = data.totalXP || 0;
+                achievements = Array.isArray(data.achievements)
+                    ? Array.from(new Set(data.achievements.filter(id => ACHIEVEMENT_DETAILS[id])))
+                    : [];
+                dayCompletion = data.dayCompletion || {};
+                activityLog = data.activityLog || {};
+                weekCompletions = data.weekCompletions || {};
+
+                const storedWeekKey = data.currentWeekKey;
+                let shouldResetWeek = false;
+                if (storedWeekKey && storedWeekKey !== nowWeekKey) {
+                    shouldResetWeek = true;
+                } else if (!storedWeekKey) {
+                    shouldResetWeek = Object.values(dayCompletion).some(info => {
+                        if (!info || !info.completionDate) {
+                            return false;
+                        }
+                        return getWeekKey(parseDateKey(info.completionDate)) !== nowWeekKey;
+                    });
+                }
+
+                if (shouldResetWeek) {
+                    resetForNewWeek();
+                }
+
+                currentWeekKey = nowWeekKey;
+            } catch (error) {
+                console.error('Failed to parse saved data', error);
+            }
+        }
+
         function saveData() {
             const data = {
                 exerciseData,
                 totalXP,
-                level,
-                streak,
-                achievements
+                achievements,
+                dayCompletion,
+                activityLog,
+                weekCompletions,
+                currentWeekKey
             };
             localStorage.setItem('goalieApp', JSON.stringify(data));
         }
 
-        // Toggle workout visibility
+        function restoreExerciseStates() {
+            Object.keys(exerciseData).forEach(key => {
+                if (!exerciseData[key]) {
+                    return;
+                }
+                const [day, index] = key.split('-');
+                const position = parseInt(index, 10);
+                if (Number.isNaN(position)) {
+                    return;
+                }
+                const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item:nth-child(${position + 1})`);
+                if (!exerciseElement) {
+                    return;
+                }
+                const checkbox = exerciseElement.querySelector('.exercise-checkbox');
+                exerciseElement.classList.add('completed');
+                if (checkbox) {
+                    checkbox.textContent = '✓';
+                    checkbox.style.background = '#10b981';
+                }
+            });
+        }
+
+        function rebuildLogsFromDayCompletion() {
+            Object.keys(dayCompletion).forEach(day => {
+                const info = dayCompletion[day];
+                if (!info || !info.isComplete) {
+                    return;
+                }
+                const dateKey = info.completionDate || getTodayKey();
+                dayCompletion[day].completionDate = dateKey;
+                addDayToLogs(day, dateKey);
+            });
+        }
+
+        function resetForNewWeek(options = {}) {
+            exerciseData = {};
+            dayCompletion = {};
+
+            if (options.resetUI) {
+                document.querySelectorAll('.exercise-list').forEach(list => {
+                    list.querySelectorAll('.exercise-item').forEach((item, index) => {
+                        item.classList.remove('completed');
+                        const checkbox = item.querySelector('.exercise-checkbox');
+                        if (checkbox) {
+                            checkbox.textContent = index + 1;
+                            checkbox.style.background = '#9ca3af';
+                        }
+                    });
+                });
+            }
+        }
+
         function toggleWorkout(day) {
             const exercises = document.getElementById(`exercises-${day}`);
             const card = document.querySelector(`[data-day="${day}"]`);
-            
-            // Hide all other workouts
+            if (!exercises || !card) {
+                return;
+            }
+
             document.querySelectorAll('.exercise-list').forEach(list => {
                 if (list.id !== `exercises-${day}`) {
                     list.classList.remove('show');
@@ -661,114 +1633,153 @@
                     c.classList.remove('active');
                 }
             });
-            
-            // Toggle current workout
+
             exercises.classList.toggle('show');
             card.classList.toggle('active');
         }
 
-        // Toggle exercise completion
-        function toggleExercise(day, index) {
-            const key = `${day}-${index}`;
-            const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item:nth-child(${index + 1})`);
-            const checkbox = exerciseElement.querySelector('.exercise-checkbox');
-            
-            if (exerciseData[key]) {
-                // Uncheck
-                exerciseData[key] = false;
-                exerciseElement.classList.remove('completed');
-                checkbox.textContent = index + 1;
-                checkbox.style.background = '#9ca3af';
-                
-                // Remove XP
-                const xpValue = parseInt(exerciseElement.querySelector('.exercise-xp').textContent);
-                totalXP = Math.max(0, totalXP - xpValue);
-            } else {
-                // Check
-                exerciseData[key] = true;
-                exerciseElement.classList.add('completed');
-                checkbox.textContent = '✓';
-                checkbox.style.background = '#10b981';
-                
-                // Add XP
-                const xpValue = parseInt(exerciseElement.querySelector('.exercise-xp').textContent);
-                totalXP += xpValue;
-                
-                // Check for first exercise achievement
-                if (!achievements.includes('first') && Object.values(exerciseData).filter(Boolean).length === 1) {
-                    achievements.push('first');
-                    document.getElementById('achievement-first').classList.add('unlocked');
-                    alert('🥇 Achievement Unlocked: First Steps!');
+        function updateWorkoutProgress(day) {
+            const meta = workoutMeta[day];
+            if (!meta) {
+                return;
+            }
+            const { totalExercises } = meta;
+            let completed = 0;
+            let earnedXP = 0;
+
+            for (let i = 0; i < totalExercises; i++) {
+                if (exerciseData[`${day}-${i}`]) {
+                    completed += 1;
+                    const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item:nth-child(${i + 1})`);
+                    if (exerciseElement) {
+                        const xpElement = exerciseElement.querySelector('.exercise-xp');
+                        const xpValue = xpElement ? parseInt(xpElement.textContent, 10) : 0;
+                        earnedXP += isNaN(xpValue) ? 0 : xpValue;
+                    }
                 }
             }
-            
+
+            const percentage = totalExercises > 0 ? (completed / totalExercises) * 100 : 0;
+            const progressFill = document.getElementById(`progress-${day}`);
+            if (progressFill) {
+                progressFill.style.width = `${percentage}%`;
+            }
+
+            const completionText = document.getElementById(`completion-${day}`);
+            if (completionText) {
+                completionText.textContent = `${Math.round(percentage)}% Complete (${completed}/${totalExercises} exercises)`;
+            }
+
+            const xpText = document.getElementById(`xp-${day}`);
+            if (xpText) {
+                xpText.textContent = earnedXP;
+            }
+
+            const isComplete = totalExercises > 0 && completed === totalExercises;
+            syncDayCompletion(day, isComplete);
+        }
+
+        function updateDisplay() {
+            level = Math.floor(totalXP / 500) + 1;
+            const xpIntoCurrentLevel = totalXP % 500;
+            const xpToNext = xpIntoCurrentLevel === 0 ? (totalXP === 0 ? 500 : 0) : 500 - xpIntoCurrentLevel;
+
+            const badge = document.getElementById('levelBadge');
+            if (badge) {
+                badge.textContent = `Level ${level}`;
+            }
+
+            const xpLabel = document.getElementById('xpProgress');
+            if (xpLabel) {
+                xpLabel.textContent = `${totalXP} XP (${xpToNext} to next level)`;
+            }
+
+            Object.keys(workoutMeta).forEach(day => updateWorkoutProgress(day));
+
+            streak = computeStreak();
+            const streakLabel = document.getElementById('streakCount');
+            if (streakLabel) {
+                streakLabel.textContent = streak;
+            }
+
+            const exerciseLabel = document.getElementById('exerciseCount');
+            if (exerciseLabel) {
+                exerciseLabel.textContent = Object.values(exerciseData).filter(Boolean).length;
+            }
+        }
+
+        function refreshAppState(options = {}) {
+            const weekKeyToday = getWeekKey(new Date());
+            if (currentWeekKey !== weekKeyToday) {
+                resetForNewWeek({ resetUI: true });
+                currentWeekKey = weekKeyToday;
+                delete weekCompletions[weekKeyToday];
+            }
+
             updateDisplay();
+            evaluateAchievements({ notify: options.notifyAchievements });
+            updateAchievementsDisplay();
+
+            const achievementLabel = document.getElementById('achievementCount');
+            if (achievementLabel) {
+                achievementLabel.textContent = achievements.length;
+            }
+
             saveData();
         }
 
-        // Update display
-        function updateDisplay() {
-            // Update level
-            level = Math.floor(totalXP / 500) + 1;
-            document.getElementById('levelBadge').textContent = `Level ${level}`;
-            document.getElementById('xpProgress').textContent = `${totalXP} XP (${500 - (totalXP % 500)} to next level)`;
-            
-            // Update stats
-            document.getElementById('streakCount').textContent = streak;
-            document.getElementById('achievementCount').textContent = achievements.length;
-            document.getElementById('exerciseCount').textContent = Object.values(exerciseData).filter(Boolean).length;
-            
-            // Update workout progress
-            updateWorkoutProgress('monday', 13, 260);
-            updateWorkoutProgress('tuesday', 13, 235);
-        }
+        function toggleExercise(day, index) {
+            const key = `${day}-${index}`;
+            const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item:nth-child(${index + 1})`);
+            if (!exerciseElement) {
+                return;
+            }
+            const checkbox = exerciseElement.querySelector('.exercise-checkbox');
 
-        // Update workout progress
-        function updateWorkoutProgress(day, totalExercises, totalXP) {
-            let completed = 0;
-            let earnedXP = 0;
-            
-            for (let i = 0; i < totalExercises; i++) {
-                if (exerciseData[`${day}-${i}`]) {
-                    completed++;
-                    const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item:nth-child(${i + 1})`);
-                    if (exerciseElement) {
-                        earnedXP += parseInt(exerciseElement.querySelector('.exercise-xp').textContent);
-                    }
+            if (exerciseData[key]) {
+                exerciseData[key] = false;
+                exerciseElement.classList.remove('completed');
+                if (checkbox) {
+                    checkbox.textContent = index + 1;
+                    checkbox.style.background = '#9ca3af';
+                }
+
+                const xpElement = exerciseElement.querySelector('.exercise-xp');
+                const xpValue = xpElement ? parseInt(xpElement.textContent, 10) : 0;
+                if (!Number.isNaN(xpValue)) {
+                    totalXP = Math.max(0, totalXP - xpValue);
+                }
+            } else {
+                exerciseData[key] = true;
+                exerciseElement.classList.add('completed');
+                if (checkbox) {
+                    checkbox.textContent = '✓';
+                    checkbox.style.background = '#10b981';
+                }
+
+                const xpElement = exerciseElement.querySelector('.exercise-xp');
+                const xpValue = xpElement ? parseInt(xpElement.textContent, 10) : 0;
+                if (!Number.isNaN(xpValue)) {
+                    totalXP += xpValue;
+                }
+
+                const completedExercises = Object.values(exerciseData).filter(Boolean).length;
+                if (!achievements.includes('first') && completedExercises === 1) {
+                    unlockAchievement('first', ACHIEVEMENT_DETAILS.first.message, true);
                 }
             }
-            
-            const percentage = (completed / totalExercises) * 100;
-            document.getElementById(`progress-${day}`).style.width = `${percentage}%`;
-            document.getElementById(`completion-${day}`).textContent = `${Math.round(percentage)}% Complete (${completed}/${totalExercises} exercises)`;
-            document.getElementById(`xp-${day}`).textContent = earnedXP;
+
+            refreshAppState({ notifyAchievements: true });
         }
 
-        // Initialize app
         document.addEventListener('DOMContentLoaded', function() {
+            initializeWorkoutMeta();
             loadData();
-            
-            // Load completed exercises from storage
-            Object.keys(exerciseData).forEach(key => {
-                if (exerciseData[key]) {
-                    const [day, index] = key.split('-');
-                    const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item:nth-child(${parseInt(index) + 1})`);
-                    if (exerciseElement) {
-                        const checkbox = exerciseElement.querySelector('.exercise-checkbox');
-                        exerciseElement.classList.add('completed');
-                        checkbox.textContent = '✓';
-                        checkbox.style.background = '#10b981';
-                    }
-                }
-            });
-            
-            // Update achievements display
-            achievements.forEach(achievement => {
-                if (achievement === 'first') {
-                    document.getElementById('achievement-first').classList.add('unlocked');
-                }
-            });
+            restoreExerciseStates();
+            rebuildLogsFromDayCompletion();
+            refreshAppState();
         });
     </script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -692,8 +692,22 @@
                 return;
             }
             container.innerHTML = '';
+            workoutMeta = {};
 
             WORKOUT_PLAN.forEach(plan => {
+                const xpValues = plan.exercises.map(exercise => {
+                    const xp = Number(exercise.xp);
+                    return Number.isFinite(xp) ? xp : 0;
+                });
+                const totalExercises = xpValues.length;
+                const totalXP = xpValues.reduce((sum, value) => sum + value, 0);
+
+                workoutMeta[plan.id] = {
+                    totalExercises,
+                    totalXP,
+                    xpValues
+                };
+
                 const card = document.createElement('div');
                 card.className = 'workout-card';
                 card.dataset.day = plan.id;
@@ -741,9 +755,9 @@
                 statusRow.style.color = '#6b7280';
                 statusRow.style.fontSize = '0.9rem';
                 statusRow.innerHTML = `
-                    <span id="completion-${plan.id}">0% Complete (0/0 exercises)</span>
+                    <span id="completion-${plan.id}">0% Complete (0/${totalExercises} exercises)</span>
                     <span style="float: right; color: #2563eb; font-weight: bold;">
-                        <span id="xp-${plan.id}">0</span>/<span id="xp-target-${plan.id}">0</span> XP
+                        <span id="xp-${plan.id}">0</span>/<span id="xp-target-${plan.id}">${totalXP}</span> XP
                     </span>
                 `;
 
@@ -766,6 +780,7 @@
                 exerciseList.id = `exercises-${plan.id}`;
 
                 plan.exercises.forEach((exercise, index) => {
+                    const xpValue = xpValues[index] || 0;
                     const item = document.createElement('div');
                     item.className = 'exercise-item';
                     item.dataset.index = index;
@@ -790,7 +805,7 @@
 
                     const xp = document.createElement('div');
                     xp.className = 'exercise-xp';
-                    xp.textContent = `${exercise.xp} XP`;
+                    xp.textContent = `${xpValue} XP`;
 
                     item.append(checkbox, info, xp);
                     exerciseList.appendChild(item);
@@ -798,38 +813,6 @@
 
                 card.append(header, progressBar, statusRow, instructions, exerciseList);
                 container.appendChild(card);
-            });
-        }
-        function initializeWorkoutMeta() {
-            workoutMeta = {};
-            document.querySelectorAll('.workout-card').forEach(card => {
-                const day = card.dataset.day;
-                if (!day) {
-                    return;
-                }
-                const exerciseItems = card.querySelectorAll('.exercise-item');
-                const totalExercises = exerciseItems.length;
-                const totalXP = Array.from(exerciseItems).reduce((sum, item) => {
-                    const xpElement = item.querySelector('.exercise-xp');
-                    const xpValue = xpElement ? parseInt(xpElement.textContent, 10) : 0;
-                    return sum + (isNaN(xpValue) ? 0 : xpValue);
-                }, 0);
-                workoutMeta[day] = { totalExercises, totalXP };
-
-                const targetSpan = document.getElementById(`xp-target-${day}`);
-                if (targetSpan) {
-                    targetSpan.textContent = totalXP;
-                }
-
-                const completionSpan = document.getElementById(`completion-${day}`);
-                if (completionSpan) {
-                    completionSpan.textContent = `0% Complete (0/${totalExercises} exercises)`;
-                }
-
-                const currentXpSpan = document.getElementById(`xp-${day}`);
-                if (currentXpSpan) {
-                    currentXpSpan.textContent = 0;
-                }
             });
         }
 
@@ -1253,19 +1236,14 @@
             if (!meta) {
                 return;
             }
-            const { totalExercises } = meta;
+            const { totalExercises, totalXP, xpValues = [] } = meta;
             let completed = 0;
             let earnedXP = 0;
 
             for (let i = 0; i < totalExercises; i++) {
                 if (exerciseData[`${day}-${i}`]) {
                     completed += 1;
-                    const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item[data-index="${i}"]`);
-                    if (exerciseElement) {
-                        const xpElement = exerciseElement.querySelector('.exercise-xp');
-                        const xpValue = xpElement ? parseInt(xpElement.textContent, 10) : 0;
-                        earnedXP += isNaN(xpValue) ? 0 : xpValue;
-                    }
+                    earnedXP += xpValues[i] || 0;
                 }
             }
 
@@ -1283,6 +1261,11 @@
             const xpText = document.getElementById(`xp-${day}`);
             if (xpText) {
                 xpText.textContent = earnedXP;
+            }
+
+            const targetText = document.getElementById(`xp-target-${day}`);
+            if (targetText) {
+                targetText.textContent = totalXP;
             }
 
             const isComplete = totalExercises > 0 && completed === totalExercises;
@@ -1346,6 +1329,7 @@
                 return;
             }
             const checkbox = exerciseElement.querySelector('.exercise-checkbox');
+            const xpValue = workoutMeta[day]?.xpValues?.[index] || 0;
 
             if (exerciseData[key]) {
                 exerciseData[key] = false;
@@ -1355,8 +1339,6 @@
                     checkbox.style.background = '#9ca3af';
                 }
 
-                const xpElement = exerciseElement.querySelector('.exercise-xp');
-                const xpValue = xpElement ? parseInt(xpElement.textContent, 10) : 0;
                 if (!Number.isNaN(xpValue)) {
                     totalXP = Math.max(0, totalXP - xpValue);
                 }
@@ -1368,8 +1350,6 @@
                     checkbox.style.background = '#10b981';
                 }
 
-                const xpElement = exerciseElement.querySelector('.exercise-xp');
-                const xpValue = xpElement ? parseInt(xpElement.textContent, 10) : 0;
                 if (!Number.isNaN(xpValue)) {
                     totalXP += xpValue;
                 }
@@ -1385,7 +1365,6 @@
 
         document.addEventListener('DOMContentLoaded', function() {
             renderWorkouts();
-            initializeWorkoutMeta();
             loadData();
             restoreExerciseStates();
             rebuildLogsFromDayCompletion();

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -11,20 +10,20 @@
             padding: 0;
             box-sizing: border-box;
         }
-        
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: #f3f4f6;
             color: #1f2937;
             line-height: 1.6;
         }
-        
+
         .container {
             max-width: 1200px;
             margin: 0 auto;
             padding: 1rem;
         }
-        
+
         .header {
             background: linear-gradient(135deg, #2563eb, #1d4ed8);
             color: white;
@@ -33,19 +32,19 @@
             margin-bottom: 2rem;
             text-align: center;
         }
-        
+
         .header h1 {
             font-size: 2.5rem;
             margin-bottom: 0.5rem;
         }
-        
+
         .stats-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
             gap: 1rem;
             margin-bottom: 2rem;
         }
-        
+
         .stat-card {
             background: white;
             padding: 1.5rem;
@@ -53,13 +52,13 @@
             text-align: center;
             box-shadow: 0 2px 8px rgba(0,0,0,0.1);
         }
-        
+
         .stat-number {
             font-size: 2rem;
             font-weight: bold;
             margin-bottom: 0.5rem;
         }
-        
+
         .workout-card {
             background: white;
             border-radius: 12px;
@@ -69,44 +68,44 @@
             cursor: pointer;
             transition: all 0.3s ease;
         }
-        
+
         .workout-card:hover {
             transform: translateY(-2px);
             box-shadow: 0 4px 16px rgba(0,0,0,0.15);
         }
-        
+
         .workout-card.active {
             border: 2px solid #2563eb;
             background: #eff6ff;
         }
-        
+
         .workout-header {
             display: flex;
             justify-content: space-between;
             align-items: center;
             margin-bottom: 1rem;
         }
-        
+
         .workout-title {
             display: flex;
             align-items: center;
             gap: 0.75rem;
         }
-        
+
         .workout-emoji {
             font-size: 2rem;
         }
-        
+
         .workout-name {
             font-size: 1.25rem;
             font-weight: bold;
         }
-        
+
         .workout-description {
             color: #6b7280;
             font-size: 0.9rem;
         }
-        
+
         .progress-bar {
             background: #e5e7eb;
             height: 8px;
@@ -114,22 +113,22 @@
             overflow: hidden;
             margin: 1rem 0;
         }
-        
+
         .progress-fill {
             height: 100%;
             background: #10b981;
             transition: width 0.3s ease;
         }
-        
+
         .exercise-list {
             display: none;
             margin-top: 1rem;
         }
-        
+
         .exercise-list.show {
             display: block;
         }
-        
+
         .exercise-item {
             display: flex;
             align-items: center;
@@ -140,16 +139,16 @@
             cursor: pointer;
             transition: all 0.2s ease;
         }
-        
+
         .exercise-item:hover {
             background: #f3f4f6;
         }
-        
+
         .exercise-item.completed {
             background: #ecfdf5;
             border: 1px solid #10b981;
         }
-        
+
         .exercise-checkbox {
             width: 24px;
             height: 24px;
@@ -163,26 +162,26 @@
             color: white;
             background: #9ca3af;
         }
-        
+
         .exercise-item.completed .exercise-checkbox {
             background: #10b981;
             border-color: #10b981;
         }
-        
+
         .exercise-info {
             flex-grow: 1;
         }
-        
+
         .exercise-name {
             font-weight: 600;
             margin-bottom: 0.25rem;
         }
-        
+
         .exercise-reps {
             color: #6b7280;
             font-size: 0.9rem;
         }
-        
+
         .exercise-xp {
             background: #fef3c7;
             color: #d97706;
@@ -195,8 +194,8 @@
         .workout-instructions {
             background: #eef2ff;
             border-left: 4px solid #6366f1;
+            padding: 1rem;
             border-radius: 8px;
-            padding: 0.75rem 1rem;
             margin: 0.75rem 0 1rem;
             color: #4338ca;
         }
@@ -215,7 +214,7 @@
             font-size: 0.9rem;
             margin-bottom: 0.35rem;
         }
-        
+
         .button {
             background: #2563eb;
             color: white;
@@ -226,30 +225,30 @@
             font-weight: 600;
             transition: background 0.2s;
         }
-        
+
         .button:hover {
             background: #1d4ed8;
         }
-        
+
         .button-small {
             padding: 0.5rem 1rem;
             font-size: 0.9rem;
         }
-        
+
         .achievements {
             background: white;
             padding: 2rem;
             border-radius: 12px;
             box-shadow: 0 2px 8px rgba(0,0,0,0.1);
         }
-        
+
         .achievement-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
             gap: 1rem;
             margin-top: 1rem;
         }
-        
+
         .achievement-item {
             display: flex;
             align-items: center;
@@ -258,26 +257,26 @@
             border-radius: 8px;
             gap: 0.75rem;
         }
-        
+
         .achievement-item.unlocked {
             border-color: #fbbf24;
             background: #fffbeb;
         }
-        
+
         .achievement-emoji {
             font-size: 2rem;
         }
-        
+
         .achievement-info h4 {
             font-weight: bold;
             margin-bottom: 0.25rem;
         }
-        
+
         .achievement-info p {
             color: #6b7280;
             font-size: 0.9rem;
         }
-        
+
         .level-badge {
             background: #fbbf24;
             color: #92400e;
@@ -286,18 +285,18 @@
             font-weight: bold;
             font-size: 1.1rem;
         }
-        
+
         .xp-progress {
             margin-top: 0.5rem;
             color: #fbbf24;
             font-size: 0.9rem;
         }
-        
+
         @media (max-width: 768px) {
             .header h1 {
                 font-size: 2rem;
             }
-            
+
             .workout-header {
                 flex-direction: column;
                 align-items: flex-start;
@@ -308,7 +307,6 @@
 </head>
 <body>
     <div class="container">
-        <!-- Header -->
         <div class="header">
             <h1>🥅 Goalie Fitness Trainer</h1>
             <p>Become the ultimate hockey goalie</p>
@@ -318,7 +316,6 @@
             </div>
         </div>
 
-        <!-- Stats -->
         <div class="stats-grid">
             <div class="stat-card">
                 <div class="stat-number" style="color: #f97316;" id="streakCount">0</div>
@@ -334,939 +331,11 @@
             </div>
         </div>
 
-        <!-- Workout Schedule -->
         <div class="workout-schedule">
             <h2 style="margin-bottom: 1.5rem; font-size: 1.8rem;">Weekly Training Schedule</h2>
-            
-            <div class="workout-card" data-day="monday">
-                <div class="workout-header">
-                    <div class="workout-title">
-                        <span class="workout-emoji">🦵</span>
-                        <div>
-                            <div class="workout-name">Monday</div>
-                            <div class="workout-description">Lower Body & Hip Mobility</div>
-                        </div>
-                    </div>
-                    <button class="button button-small" onclick="toggleWorkout('monday')">Start Workout</button>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" id="progress-monday" style="width: 0%"></div>
-                </div>
-                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
-                    <span id="completion-monday">0% Complete (0/0 exercises)</span>
-                    <span style="float: right; color: #2563eb; font-weight: bold;">
-                        <span id="xp-monday">0</span>/<span id="xp-target-monday">0</span> XP
-                    </span>
-                </div>
-
-                <div class="workout-instructions">
-                    <p><strong>Instructions:</strong> Build explosive leg power while keeping pristine movement quality.</p>
-                    <ul>
-                        <li>Use a light dynamic warm-up before the first strength set and ease into depth on squats and lunges.</li>
-                        <li>Rest 45-60 seconds between sets and chase controlled tempo rather than speed.</li>
-                        <li>Hold stretches for the full prescribed time and breathe through each range.</li>
-                    </ul>
-                </div>
-                
-                <div class="exercise-list" id="exercises-monday">
-                    <div class="exercise-item" onclick="toggleExercise('monday', 0)">
-                        <div class="exercise-checkbox">1</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Leg Swings</div>
-                            <div class="exercise-reps">10 each direction/leg</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 1)">
-                        <div class="exercise-checkbox">2</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Hip Circles</div>
-                            <div class="exercise-reps">10 each direction</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 2)">
-                        <div class="exercise-checkbox">3</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Bodyweight Squats</div>
-                            <div class="exercise-reps">15 reps</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 3)">
-                        <div class="exercise-checkbox">4</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Walking Lunges</div>
-                            <div class="exercise-reps">10 each leg</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 4)">
-                        <div class="exercise-checkbox">5</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Goblet Squats</div>
-                            <div class="exercise-reps">12-15 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 5)">
-                        <div class="exercise-checkbox">6</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Single-Leg Romanian Deadlifts</div>
-                            <div class="exercise-reps">8 each leg × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 6)">
-                        <div class="exercise-checkbox">7</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Lateral Lunges</div>
-                            <div class="exercise-reps">10 each side × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 7)">
-                        <div class="exercise-checkbox">8</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Glute Bridges</div>
-                            <div class="exercise-reps">15 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 8)">
-                        <div class="exercise-checkbox">9</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Cossack Squats</div>
-                            <div class="exercise-reps">6 each side × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">30 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 9)">
-                        <div class="exercise-checkbox">10</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">90/90 Hip Stretch</div>
-                            <div class="exercise-reps">1 min each side</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 10)">
-                        <div class="exercise-checkbox">11</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Pigeon Pose</div>
-                            <div class="exercise-reps">1 min each side</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 11)">
-                        <div class="exercise-checkbox">12</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Hip Flexor Stretch</div>
-                            <div class="exercise-reps">1 min each side</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('monday', 12)">
-                        <div class="exercise-checkbox">13</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Deep Squat Hold</div>
-                            <div class="exercise-reps">2 minutes</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="workout-card" data-day="tuesday">
-                <div class="workout-header">
-                    <div class="workout-title">
-                        <span class="workout-emoji">💪</span>
-                        <div>
-                            <div class="workout-name">Tuesday</div>
-                            <div class="workout-description">Upper Body & Core</div>
-                        </div>
-                    </div>
-                    <button class="button button-small" onclick="toggleWorkout('tuesday')">Start Workout</button>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" id="progress-tuesday" style="width: 0%"></div>
-                </div>
-                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
-                    <span id="completion-tuesday">0% Complete (0/0 exercises)</span>
-                    <span style="float: right; color: #2563eb; font-weight: bold;">
-                        <span id="xp-tuesday">0</span>/<span id="xp-target-tuesday">0</span> XP
-                    </span>
-                </div>
-
-                <div class="workout-instructions">
-                    <p><strong>Instructions:</strong> Prime the upper body for resilient saves and stay braced through the core.</p>
-                    <ul>
-                        <li>Move smoothly through the mobility pieces before loading resistance moves.</li>
-                        <li>Keep ribs stacked over hips during pressing and plank variations to protect your back.</li>
-                        <li>Cap each set one rep shy of failure so you can finish the session with crisp form.</li>
-                    </ul>
-                </div>
-
-                
-                <div class="exercise-list" id="exercises-tuesday">
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 0)">
-                        <div class="exercise-checkbox">1</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Arm Circles</div>
-                            <div class="exercise-reps">10 each direction</div>
-                        </div>
-                        <div class="exercise-xp">10 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 1)">
-                        <div class="exercise-checkbox">2</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Shoulder Rolls</div>
-                            <div class="exercise-reps">10 backwards</div>
-                        </div>
-                        <div class="exercise-xp">10 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 2)">
-                        <div class="exercise-checkbox">3</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Cat-Cow Stretches</div>
-                            <div class="exercise-reps">10 reps</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 3)">
-                        <div class="exercise-checkbox">4</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Plank Hold</div>
-                            <div class="exercise-reps">30 seconds</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 4)">
-                        <div class="exercise-checkbox">5</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Push-ups</div>
-                            <div class="exercise-reps">10-15 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 5)">
-                        <div class="exercise-checkbox">6</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Resistance Band Rows</div>
-                            <div class="exercise-reps">15 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 6)">
-                        <div class="exercise-checkbox">7</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Pike Push-ups</div>
-                            <div class="exercise-reps">8-12 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 7)">
-                        <div class="exercise-checkbox">8</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Face Pulls</div>
-                            <div class="exercise-reps">15 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 8)">
-                        <div class="exercise-checkbox">9</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">External Rotations</div>
-                            <div class="exercise-reps">12 each arm × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 9)">
-                        <div class="exercise-checkbox">10</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Dead Bug</div>
-                            <div class="exercise-reps">10 each side × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 10)">
-                        <div class="exercise-checkbox">11</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Side Plank</div>
-                            <div class="exercise-reps">30 sec each side × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 11)">
-                        <div class="exercise-checkbox">12</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Bird Dog</div>
-                            <div class="exercise-reps">10 each side × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('tuesday', 12)">
-                        <div class="exercise-checkbox">13</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Pallof Press</div>
-                            <div class="exercise-reps">10 each side × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="workout-card" data-day="wednesday">
-                <div class="workout-header">
-                    <div class="workout-title">
-                        <span class="workout-emoji">⚡</span>
-                        <div>
-                            <div class="workout-name">Wednesday</div>
-                            <div class="workout-description">Agility & Lateral Quickness</div>
-                        </div>
-                    </div>
-                    <button class="button button-small" onclick="toggleWorkout('wednesday')">Start Workout</button>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" id="progress-wednesday" style="width: 0%"></div>
-                </div>
-                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
-                    <span id="completion-wednesday">0% Complete (0/0 exercises)</span>
-                    <span style="float: right; color: #2563eb; font-weight: bold;">
-                        <span id="xp-wednesday">0</span>/<span id="xp-target-wednesday">0</span> XP
-                    </span>
-                </div>
-
-                <div class="workout-instructions">
-                    <p><strong>Instructions:</strong> Stay light on your edges and push for fast feet without sacrificing stance.</p>
-                    <ul>
-                        <li>Drive knees over toes during lateral moves and stick the landing before exploding again.</li>
-                        <li>Keep torso tall and eyes forward so you can react quickly like you would in the crease.</li>
-                        <li>Recover with 30-40 seconds of easy movement between explosive intervals.</li>
-                    </ul>
-                </div>
-
-                <div class="exercise-list" id="exercises-wednesday">
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 0)">
-                        <div class="exercise-checkbox">1</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Jump Rope Warm-up</div>
-                            <div class="exercise-reps">3 minutes steady pace</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 1)">
-                        <div class="exercise-checkbox">2</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Lateral Line Hops</div>
-                            <div class="exercise-reps">20 each side × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 2)">
-                        <div class="exercise-checkbox">3</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Agility Ladder In-Out</div>
-                            <div class="exercise-reps">4 rounds down and back</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 3)">
-                        <div class="exercise-checkbox">4</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">T-Drill Shuffle</div>
-                            <div class="exercise-reps">5 patterns, reset tall stance</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 4)">
-                        <div class="exercise-checkbox">5</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Lateral Bounds</div>
-                            <div class="exercise-reps">12 each side × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">30 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 5)">
-                        <div class="exercise-checkbox">6</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Cone Shuffle Patterns</div>
-                            <div class="exercise-reps">5 rounds with quick pivots</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 6)">
-                        <div class="exercise-checkbox">7</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Carioca Steps</div>
-                            <div class="exercise-reps">3 lengths each direction</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 7)">
-                        <div class="exercise-checkbox">8</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Quick Feet to Sprawl</div>
-                            <div class="exercise-reps">12 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 8)">
-                        <div class="exercise-checkbox">9</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Reaction Ball Toss</div>
-                            <div class="exercise-reps">3 rounds × 45 seconds</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 9)">
-                        <div class="exercise-checkbox">10</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Shuttle Sprints</div>
-                            <div class="exercise-reps">6 × 20 meter efforts</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 10)">
-                        <div class="exercise-checkbox">11</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Box Jumps with Stick</div>
-                            <div class="exercise-reps">10 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">30 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('wednesday', 11)">
-                        <div class="exercise-checkbox">12</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Dynamic Cool Down</div>
-                            <div class="exercise-reps">5 minutes easy mobility</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="workout-card" data-day="thursday">
-                <div class="workout-header">
-                    <div class="workout-title">
-                        <span class="workout-emoji">🧘‍♂️</span>
-                        <div>
-                            <div class="workout-name">Thursday</div>
-                            <div class="workout-description">Recovery & Mobility Reset</div>
-                        </div>
-                    </div>
-                    <button class="button button-small" onclick="toggleWorkout('thursday')">Start Workout</button>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" id="progress-thursday" style="width: 0%"></div>
-                </div>
-                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
-                    <span id="completion-thursday">0% Complete (0/0 exercises)</span>
-                    <span style="float: right; color: #2563eb; font-weight: bold;">
-                        <span id="xp-thursday">0</span>/<span id="xp-target-thursday">0</span> XP
-                    </span>
-                </div>
-
-                <div class="workout-instructions">
-                    <p><strong>Instructions:</strong> Ease tension and refill the tank before the weekend push.</p>
-                    <ul>
-                        <li>Spend extra time on hotspots—foam rolling and stretching should feel restorative, not rushed.</li>
-                        <li>Breathe slowly through each mobility drill and relax shoulders away from ears.</li>
-                        <li>Keep the heart rate low; this is about quality recovery and range of motion.</li>
-                    </ul>
-                </div>
-
-                <div class="exercise-list" id="exercises-thursday">
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 0)">
-                        <div class="exercise-checkbox">1</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Foam Roll Lower Body</div>
-                            <div class="exercise-reps">2 minutes per major muscle group</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 1)">
-                        <div class="exercise-checkbox">2</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Banded Ankle Mobilizations</div>
-                            <div class="exercise-reps">15 rocks each side × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 2)">
-                        <div class="exercise-checkbox">3</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Thoracic Open Book Rotations</div>
-                            <div class="exercise-reps">10 each side × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 3)">
-                        <div class="exercise-checkbox">4</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">World's Greatest Stretch</div>
-                            <div class="exercise-reps">6 each side with pause</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 4)">
-                        <div class="exercise-checkbox">5</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Hamstring Flossing</div>
-                            <div class="exercise-reps">15 reps each leg × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 5)">
-                        <div class="exercise-checkbox">6</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Adductor Rock Back Stretch</div>
-                            <div class="exercise-reps">45 seconds each side × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 6)">
-                        <div class="exercise-checkbox">7</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Half-Kneeling Hip Flexor Stretch</div>
-                            <div class="exercise-reps">60 seconds each side × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 7)">
-                        <div class="exercise-checkbox">8</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Prone Press-Ups</div>
-                            <div class="exercise-reps">10 slow reps × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 8)">
-                        <div class="exercise-checkbox">9</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Child's Pose Breathing</div>
-                            <div class="exercise-reps">3 rounds × 5 deep breaths</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 9)">
-                        <div class="exercise-checkbox">10</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Supine Spinal Twist</div>
-                            <div class="exercise-reps">45 seconds each side</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 10)">
-                        <div class="exercise-checkbox">11</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Diaphragmatic Breathing</div>
-                            <div class="exercise-reps">4 minutes nasal breathing</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('thursday', 11)">
-                        <div class="exercise-checkbox">12</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Contrast Shower or Ice Bath</div>
-                            <div class="exercise-reps">5-7 minutes alternated</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="workout-card" data-day="friday">
-                <div class="workout-header">
-                    <div class="workout-title">
-                        <span class="workout-emoji">🏋️‍♂️</span>
-                        <div>
-                            <div class="workout-name">Friday</div>
-                            <div class="workout-description">Strength & Power Finish</div>
-                        </div>
-                    </div>
-                    <button class="button button-small" onclick="toggleWorkout('friday')">Start Workout</button>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" id="progress-friday" style="width: 0%"></div>
-                </div>
-                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
-                    <span id="completion-friday">0% Complete (0/0 exercises)</span>
-                    <span style="float: right; color: #2563eb; font-weight: bold;">
-                        <span id="xp-friday">0</span>/<span id="xp-target-friday">0</span> XP
-                    </span>
-                </div>
-
-                <div class="workout-instructions">
-                    <p><strong>Instructions:</strong> Attack the lifts with intent and stick every landing like a highlight reel save.</p>
-                    <ul>
-                        <li>Complete a thorough dynamic warm-up before loading heavier movements.</li>
-                        <li>Use powerful concentric drives and a two-count controlled lowering phase.</li>
-                        <li>Rest 90 seconds between big lifts and 60 seconds on accessory work.</li>
-                    </ul>
-                </div>
-
-                <div class="exercise-list" id="exercises-friday">
-                    <div class="exercise-item" onclick="toggleExercise('friday', 0)">
-                        <div class="exercise-checkbox">1</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Dynamic Warm-up Flow</div>
-                            <div class="exercise-reps">5 minutes of movement prep</div>
-                        </div>
-                        <div class="exercise-xp">10 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 1)">
-                        <div class="exercise-checkbox">2</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Medicine Ball Slams</div>
-                            <div class="exercise-reps">10 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 2)">
-                        <div class="exercise-checkbox">3</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Kettlebell Swings</div>
-                            <div class="exercise-reps">15 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 3)">
-                        <div class="exercise-checkbox">4</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Trap Bar Deadlift</div>
-                            <div class="exercise-reps">5 reps × 4 sets (heavy)</div>
-                        </div>
-                        <div class="exercise-xp">30 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 4)">
-                        <div class="exercise-checkbox">5</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Rear Foot Elevated Split Squat</div>
-                            <div class="exercise-reps">8 each leg × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 5)">
-                        <div class="exercise-checkbox">6</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Single-Leg Box Squat</div>
-                            <div class="exercise-reps">8 each leg × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 6)">
-                        <div class="exercise-checkbox">7</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Bulgarian Split Squat Jumps</div>
-                            <div class="exercise-reps">6 each leg × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">30 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 7)">
-                        <div class="exercise-checkbox">8</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Standing Broad Jumps</div>
-                            <div class="exercise-reps">6 jumps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 8)">
-                        <div class="exercise-checkbox">9</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Push Press</div>
-                            <div class="exercise-reps">6 reps × 4 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 9)">
-                        <div class="exercise-checkbox">10</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Farmer's Carry</div>
-                            <div class="exercise-reps">40 meters × 3 trips</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 10)">
-                        <div class="exercise-checkbox">11</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Ab Wheel or TRX Rollouts</div>
-                            <div class="exercise-reps">10 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('friday', 11)">
-                        <div class="exercise-checkbox">12</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Cooldown Stretch Series</div>
-                            <div class="exercise-reps">5 minutes focused mobility</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="workout-card" data-day="saturday">
-                <div class="workout-header">
-                    <div class="workout-title">
-                        <span class="workout-emoji">🔥</span>
-                        <div>
-                            <div class="workout-name">Saturday</div>
-                            <div class="workout-description">Conditioning & Crease Simulation</div>
-                        </div>
-                    </div>
-                    <button class="button button-small" onclick="toggleWorkout('saturday')">Start Workout</button>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" id="progress-saturday" style="width: 0%"></div>
-                </div>
-                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
-                    <span id="completion-saturday">0% Complete (0/0 exercises)</span>
-                    <span style="float: right; color: #2563eb; font-weight: bold;">
-                        <span id="xp-saturday">0</span>/<span id="xp-target-saturday">0</span> XP
-                    </span>
-                </div>
-
-                <div class="workout-instructions">
-                    <p><strong>Instructions:</strong> Mimic the chaos of a game—quick bursts, sharp stops, and rapid recoveries.</p>
-                    <ul>
-                        <li>Keep movements crisp with athletic posture; imagine tracking the puck during every change of direction.</li>
-                        <li>Push intensity on intervals, then reset breathing through the nose during rest.</li>
-                        <li>Finish with mobility and visualization so you walk away energized, not crushed.</li>
-                    </ul>
-                </div>
-
-                <div class="exercise-list" id="exercises-saturday">
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 0)">
-                        <div class="exercise-checkbox">1</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Dynamic Skater Warm-up</div>
-                            <div class="exercise-reps">5 minutes flowing drills</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 1)">
-                        <div class="exercise-checkbox">2</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Lateral Shuffle Intervals</div>
-                            <div class="exercise-reps">6 rounds × 30 seconds on/30 seconds off</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 2)">
-                        <div class="exercise-checkbox">3</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Suicide Sprints</div>
-                            <div class="exercise-reps">4 sets through 5 markers</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 3)">
-                        <div class="exercise-checkbox">4</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Bike Sprint Intervals</div>
-                            <div class="exercise-reps">8 rounds × 15 seconds all-out</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 4)">
-                        <div class="exercise-checkbox">5</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Battle Rope Slams</div>
-                            <div class="exercise-reps">4 rounds × 30 seconds</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 5)">
-                        <div class="exercise-checkbox">6</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Bear Crawl Patterns</div>
-                            <div class="exercise-reps">3 rounds forward/backward</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 6)">
-                        <div class="exercise-checkbox">7</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Slide Board Lateral Drives</div>
-                            <div class="exercise-reps">4 rounds × 45 seconds</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 7)">
-                        <div class="exercise-checkbox">8</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Burpee to Lateral Jump</div>
-                            <div class="exercise-reps">12 reps × 3 sets</div>
-                        </div>
-                        <div class="exercise-xp">25 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 8)">
-                        <div class="exercise-checkbox">9</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Mountain Climbers</div>
-                            <div class="exercise-reps">3 rounds × 45 seconds</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 9)">
-                        <div class="exercise-checkbox">10</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Jump Rope Cooldown</div>
-                            <div class="exercise-reps">4 minutes light pace</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 10)">
-                        <div class="exercise-checkbox">11</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Lower Body Mobility Flow</div>
-                            <div class="exercise-reps">5 minutes focus on hips</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('saturday', 11)">
-                        <div class="exercise-checkbox">12</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Performance Visualization</div>
-                            <div class="exercise-reps">5 minutes eyes closed</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="workout-card" data-day="sunday">
-                <div class="workout-header">
-                    <div class="workout-title">
-                        <span class="workout-emoji">🌿</span>
-                        <div>
-                            <div class="workout-name">Sunday</div>
-                            <div class="workout-description">Stability & Mindfulness</div>
-                        </div>
-                    </div>
-                    <button class="button button-small" onclick="toggleWorkout('sunday')">Start Workout</button>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" id="progress-sunday" style="width: 0%"></div>
-                </div>
-                <div style="margin-top: 0.5rem; color: #6b7280; font-size: 0.9rem;">
-                    <span id="completion-sunday">0% Complete (0/0 exercises)</span>
-                    <span style="float: right; color: #2563eb; font-weight: bold;">
-                        <span id="xp-sunday">0</span>/<span id="xp-target-sunday">0</span> XP
-                    </span>
-                </div>
-
-                <div class="workout-instructions">
-                    <p><strong>Instructions:</strong> Shift into active recovery and set the tone for next week.</p>
-                    <ul>
-                        <li>Move intentionally through balance work—quality time on each leg beats racing the clock.</li>
-                        <li>Focus on controlled breathing to reset the nervous system.</li>
-                        <li>Finish with reflection so you start Monday prepared and confident.</li>
-                    </ul>
-                </div>
-
-                <div class="exercise-list" id="exercises-sunday">
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 0)">
-                        <div class="exercise-checkbox">1</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Gentle Mobility Warm-up</div>
-                            <div class="exercise-reps">5 minutes easy range of motion</div>
-                        </div>
-                        <div class="exercise-xp">10 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 1)">
-                        <div class="exercise-checkbox">2</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Yoga Sun Salutations</div>
-                            <div class="exercise-reps">5 slow rounds</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 2)">
-                        <div class="exercise-checkbox">3</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Balance Board Holds</div>
-                            <div class="exercise-reps">3 rounds × 45 seconds</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 3)">
-                        <div class="exercise-checkbox">4</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Single-Leg Reach Matrix</div>
-                            <div class="exercise-reps">6 each direction per leg</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 4)">
-                        <div class="exercise-checkbox">5</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Dead Bug Iso Hold</div>
-                            <div class="exercise-reps">3 rounds × 30 seconds</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 5)">
-                        <div class="exercise-checkbox">6</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Side Plank with Leg Lift</div>
-                            <div class="exercise-reps">3 rounds × 30 seconds each side</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 6)">
-                        <div class="exercise-checkbox">7</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Mini-Band Glute Activation</div>
-                            <div class="exercise-reps">15 reps each move × 2 sets</div>
-                        </div>
-                        <div class="exercise-xp">20 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 7)">
-                        <div class="exercise-checkbox">8</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Hip Capsule Stretch</div>
-                            <div class="exercise-reps">45 seconds each side</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 8)">
-                        <div class="exercise-checkbox">9</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Seated Hamstring Stretch</div>
-                            <div class="exercise-reps">60 seconds each leg</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 9)">
-                        <div class="exercise-checkbox">10</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Box Breathing</div>
-                            <div class="exercise-reps">6 rounds of 4-4-4-4</div>
-                        </div>
-                        <div class="exercise-xp">15 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 10)">
-                        <div class="exercise-checkbox">11</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Performance Journal Reflection</div>
-                            <div class="exercise-reps">10 minutes writing wins & lessons</div>
-                        </div>
-                        <div class="exercise-xp">10 XP</div>
-                    </div>
-                    <div class="exercise-item" onclick="toggleExercise('sunday', 11)">
-                        <div class="exercise-checkbox">12</div>
-                        <div class="exercise-info">
-                            <div class="exercise-name">Plan Upcoming Week</div>
-                            <div class="exercise-reps">Review schedule & goals</div>
-                        </div>
-                        <div class="exercise-xp">10 XP</div>
-                    </div>
-                </div>
-            </div>
+            <div id="workoutCards"></div>
         </div>
 
-        <!-- Achievements -->
         <div class="achievements">
             <h2 style="margin-bottom: 1rem; font-size: 1.8rem;">🏆 Achievements</h2>
             <div class="achievement-grid">
@@ -1303,7 +372,206 @@
     </div>
 
     <script>
-        const workoutMeta = {};
+        const WORKOUT_PLAN = [
+            {
+                id: "monday",
+                emoji: "🦵",
+                title: "Monday",
+                description: "Lower Body & Hip Mobility",
+                instructions: {
+                    intro: "Build explosive leg power while keeping pristine movement quality.",
+                    bullets: [
+                        "Use a light dynamic warm-up before the first strength set and ease into depth on squats and lunges.",
+                        "Rest 45-60 seconds between sets and chase controlled tempo rather than speed.",
+                        "Hold stretches for the full prescribed time and breathe through each range."
+                    ]
+                },
+                exercises: [
+                    { name: "Leg Swings", reps: "10 each direction/leg", xp: 15 },
+                    { name: "Hip Circles", reps: "10 each direction", xp: 15 },
+                    { name: "Bodyweight Squats", reps: "15 reps", xp: 20 },
+                    { name: "Walking Lunges", reps: "10 each leg", xp: 20 },
+                    { name: "Goblet Squats", reps: "12-15 reps × 3 sets", xp: 25 },
+                    { name: "Single-Leg Romanian Deadlifts", reps: "8 each leg × 3 sets", xp: 25 },
+                    { name: "Lateral Lunges", reps: "10 each side × 3 sets", xp: 25 },
+                    { name: "Glute Bridges", reps: "15 reps × 3 sets", xp: 20 },
+                    { name: "Cossack Squats", reps: "6 each side × 3 sets", xp: 30 },
+                    { name: "90/90 Hip Stretch", reps: "1 min each side", xp: 15 },
+                    { name: "Pigeon Pose", reps: "1 min each side", xp: 15 },
+                    { name: "Hip Flexor Stretch", reps: "1 min each side", xp: 15 },
+                    { name: "Deep Squat Hold", reps: "2 minutes", xp: 20 }
+                ]
+            },
+            {
+                id: "tuesday",
+                emoji: "💪",
+                title: "Tuesday",
+                description: "Upper Body & Core",
+                instructions: {
+                    intro: "Prime the upper body for resilient saves and stay braced through the core.",
+                    bullets: [
+                        "Move smoothly through the mobility pieces before loading resistance moves.",
+                        "Keep ribs stacked over hips during pressing and plank variations to protect your back.",
+                        "Cap each set one rep shy of failure so you can finish the session with crisp form."
+                    ]
+                },
+                exercises: [
+                    { name: "Arm Circles", reps: "10 each direction", xp: 10 },
+                    { name: "Shoulder Rolls", reps: "10 backwards", xp: 10 },
+                    { name: "Cat-Cow Stretches", reps: "10 reps", xp: 15 },
+                    { name: "Plank Hold", reps: "30 seconds", xp: 15 },
+                    { name: "Push-ups", reps: "10-15 reps × 3 sets", xp: 25 },
+                    { name: "Resistance Band Rows", reps: "15 reps × 3 sets", xp: 20 },
+                    { name: "Pike Push-ups", reps: "8-12 reps × 3 sets", xp: 25 },
+                    { name: "Face Pulls", reps: "15 reps × 3 sets", xp: 20 },
+                    { name: "External Rotations", reps: "12 each arm × 3 sets", xp: 20 },
+                    { name: "Dead Bug", reps: "10 each side × 2 sets", xp: 20 },
+                    { name: "Side Plank", reps: "30 sec each side × 2 sets", xp: 25 },
+                    { name: "Bird Dog", reps: "10 each side × 2 sets", xp: 20 },
+                    { name: "Pallof Press", reps: "10 each side × 2 sets", xp: 25 }
+                ]
+            },
+            {
+                id: "wednesday",
+                emoji: "⚡",
+                title: "Wednesday",
+                description: "Agility & Lateral Quickness",
+                instructions: {
+                    intro: "Stay light on your edges and push for fast feet without sacrificing stance.",
+                    bullets: [
+                        "Drive knees over toes during lateral moves and stick the landing before exploding again.",
+                        "Keep torso tall and eyes forward so you can react quickly like you would in the crease.",
+                        "Recover with 30-40 seconds of easy movement between explosive intervals."
+                    ]
+                },
+                exercises: [
+                    { name: "Jump Rope Warm-up", reps: "3 minutes steady pace", xp: 15 },
+                    { name: "Lateral Line Hops", reps: "20 each side × 2 sets", xp: 20 },
+                    { name: "Agility Ladder In-Out", reps: "4 rounds down and back", xp: 20 },
+                    { name: "T-Drill Shuffle", reps: "5 patterns, reset tall stance", xp: 25 },
+                    { name: "Lateral Bounds", reps: "12 each side × 3 sets", xp: 30 },
+                    { name: "Cone Shuffle Patterns", reps: "5 rounds with quick pivots", xp: 25 },
+                    { name: "Carioca Steps", reps: "3 lengths each direction", xp: 15 },
+                    { name: "Quick Feet to Sprawl", reps: "12 reps × 3 sets", xp: 25 },
+                    { name: "Reaction Ball Toss", reps: "3 rounds × 45 seconds", xp: 20 },
+                    { name: "Shuttle Sprints", reps: "6 × 20 meter efforts", xp: 25 },
+                    { name: "Box Jumps with Stick", reps: "10 reps × 3 sets", xp: 30 },
+                    { name: "Dynamic Cool Down", reps: "5 minutes easy mobility", xp: 15 }
+                ]
+            },
+            {
+                id: "thursday",
+                emoji: "🧘‍♂️",
+                title: "Thursday",
+                description: "Recovery & Mobility Reset",
+                instructions: {
+                    intro: "Ease tension and refill the tank before the weekend push.",
+                    bullets: [
+                        "Spend extra time on hotspots—foam rolling and stretching should feel restorative, not rushed.",
+                        "Breathe slowly through each mobility drill and relax shoulders away from ears.",
+                        "Keep the heart rate low; this is about quality recovery and range of motion."
+                    ]
+                },
+                exercises: [
+                    { name: "Foam Roll Lower Body", reps: "2 minutes per major muscle group", xp: 15 },
+                    { name: "Banded Ankle Mobilizations", reps: "15 rocks each side × 2 sets", xp: 15 },
+                    { name: "Thoracic Open Book Rotations", reps: "10 each side × 2 sets", xp: 20 },
+                    { name: "World's Greatest Stretch", reps: "6 each side with pause", xp: 20 },
+                    { name: "Hamstring Flossing", reps: "15 reps each leg × 2 sets", xp: 20 },
+                    { name: "Adductor Rock Back Stretch", reps: "45 seconds each side × 2 sets", xp: 20 },
+                    { name: "Half-Kneeling Hip Flexor Stretch", reps: "60 seconds each side × 2 sets", xp: 20 },
+                    { name: "Prone Press-Ups", reps: "10 slow reps × 2 sets", xp: 15 },
+                    { name: "Child's Pose Breathing", reps: "3 rounds × 5 deep breaths", xp: 15 },
+                    { name: "Supine Spinal Twist", reps: "45 seconds each side", xp: 15 },
+                    { name: "Diaphragmatic Breathing", reps: "4 minutes nasal breathing", xp: 15 },
+                    { name: "Contrast Shower or Ice Bath", reps: "5-7 minutes alternated", xp: 15 }
+                ]
+            },
+            {
+                id: "friday",
+                emoji: "🏋️‍♂️",
+                title: "Friday",
+                description: "Strength & Power Finish",
+                instructions: {
+                    intro: "Attack the lifts with intent and stick every landing like a highlight reel save.",
+                    bullets: [
+                        "Complete a thorough dynamic warm-up before loading heavier movements.",
+                        "Use powerful concentric drives and a two-count controlled lowering phase.",
+                        "Rest 90 seconds between big lifts and 60 seconds on accessory work."
+                    ]
+                },
+                exercises: [
+                    { name: "Dynamic Warm-up Flow", reps: "5 minutes of movement prep", xp: 10 },
+                    { name: "Medicine Ball Slams", reps: "10 reps × 3 sets", xp: 25 },
+                    { name: "Kettlebell Swings", reps: "15 reps × 3 sets", xp: 25 },
+                    { name: "Trap Bar Deadlift", reps: "5 reps × 4 sets (heavy)", xp: 30 },
+                    { name: "Rear Foot Elevated Split Squat", reps: "8 each leg × 3 sets", xp: 25 },
+                    { name: "Single-Leg Box Squat", reps: "8 each leg × 3 sets", xp: 25 },
+                    { name: "Bulgarian Split Squat Jumps", reps: "6 each leg × 3 sets", xp: 30 },
+                    { name: "Standing Broad Jumps", reps: "6 jumps × 3 sets", xp: 25 },
+                    { name: "Push Press", reps: "6 reps × 4 sets", xp: 25 },
+                    { name: "Farmer's Carry", reps: "40 meters × 3 trips", xp: 20 },
+                    { name: "Ab Wheel or TRX Rollouts", reps: "10 reps × 3 sets", xp: 20 },
+                    { name: "Cooldown Stretch Series", reps: "5 minutes focused mobility", xp: 15 }
+                ]
+            },
+            {
+                id: "saturday",
+                emoji: "🔥",
+                title: "Saturday",
+                description: "Conditioning & Crease Simulation",
+                instructions: {
+                    intro: "Mimic the chaos of a game—quick bursts, sharp stops, and rapid recoveries.",
+                    bullets: [
+                        "Keep movements crisp with athletic posture; imagine tracking the puck during every change of direction.",
+                        "Push intensity on intervals, then reset breathing through the nose during rest.",
+                        "Finish with mobility and visualization so you walk away energized, not crushed."
+                    ]
+                },
+                exercises: [
+                    { name: "Dynamic Skater Warm-up", reps: "5 minutes flowing drills", xp: 15 },
+                    { name: "Lateral Shuffle Intervals", reps: "6 rounds × 30 seconds on/30 seconds off", xp: 25 },
+                    { name: "Suicide Sprints", reps: "4 sets through 5 markers", xp: 25 },
+                    { name: "Bike Sprint Intervals", reps: "8 rounds × 15 seconds all-out", xp: 25 },
+                    { name: "Battle Rope Slams", reps: "4 rounds × 30 seconds", xp: 20 },
+                    { name: "Bear Crawl Patterns", reps: "3 rounds forward/backward", xp: 20 },
+                    { name: "Slide Board Lateral Drives", reps: "4 rounds × 45 seconds", xp: 25 },
+                    { name: "Burpee to Lateral Jump", reps: "12 reps × 3 sets", xp: 25 },
+                    { name: "Mountain Climbers", reps: "3 rounds × 45 seconds", xp: 20 },
+                    { name: "Jump Rope Cooldown", reps: "4 minutes light pace", xp: 15 },
+                    { name: "Lower Body Mobility Flow", reps: "5 minutes focus on hips", xp: 15 },
+                    { name: "Performance Visualization", reps: "5 minutes eyes closed", xp: 15 }
+                ]
+            },
+            {
+                id: "sunday",
+                emoji: "🌿",
+                title: "Sunday",
+                description: "Stability & Mindfulness",
+                instructions: {
+                    intro: "Shift into active recovery and set the tone for next week.",
+                    bullets: [
+                        "Move intentionally through balance work—quality time on each leg beats racing the clock.",
+                        "Focus on controlled breathing to reset the nervous system.",
+                        "Finish with reflection so you start Monday prepared and confident."
+                    ]
+                },
+                exercises: [
+                    { name: "Gentle Mobility Warm-up", reps: "5 minutes easy range of motion", xp: 10 },
+                    { name: "Yoga Sun Salutations", reps: "5 slow rounds", xp: 20 },
+                    { name: "Balance Board Holds", reps: "3 rounds × 45 seconds", xp: 20 },
+                    { name: "Single-Leg Reach Matrix", reps: "6 each direction per leg", xp: 20 },
+                    { name: "Dead Bug Iso Hold", reps: "3 rounds × 30 seconds", xp: 20 },
+                    { name: "Side Plank with Leg Lift", reps: "3 rounds × 30 seconds each side", xp: 20 },
+                    { name: "Mini-Band Glute Activation", reps: "15 reps each move × 2 sets", xp: 20 },
+                    { name: "Hip Capsule Stretch", reps: "45 seconds each side", xp: 15 },
+                    { name: "Seated Hamstring Stretch", reps: "60 seconds each leg", xp: 15 },
+                    { name: "Box Breathing", reps: "6 rounds of 4-4-4-4", xp: 15 },
+                    { name: "Performance Journal Reflection", reps: "10 minutes writing wins & lessons", xp: 10 },
+                    { name: "Plan Upcoming Week", reps: "Review schedule & goals", xp: 10 }
+                ]
+            }
+        ];
         const ACHIEVEMENT_DETAILS = {
             first: { elementId: 'achievement-first', message: '🥇 Achievement Unlocked: First Steps!' },
             week: { elementId: 'achievement-week', message: '⚔️ Achievement Unlocked: Week Warrior!' },
@@ -1311,17 +579,133 @@
             goalie: { elementId: 'achievement-goalie', message: '🥅 Achievement Unlocked: Goalie God!' }
         };
 
+        let workoutMeta = {};
         let exerciseData = {};
         let totalXP = 0;
+        let achievements = [];
         let level = 1;
         let streak = 0;
-        let achievements = [];
         let dayCompletion = {};
         let activityLog = {};
         let weekCompletions = {};
         let currentWeekKey = null;
 
+        function renderWorkouts() {
+            const container = document.getElementById('workoutCards');
+            if (!container) {
+                return;
+            }
+            container.innerHTML = '';
+
+            WORKOUT_PLAN.forEach(plan => {
+                const card = document.createElement('div');
+                card.className = 'workout-card';
+                card.dataset.day = plan.id;
+
+                const header = document.createElement('div');
+                header.className = 'workout-header';
+
+                const title = document.createElement('div');
+                title.className = 'workout-title';
+
+                const emoji = document.createElement('span');
+                emoji.className = 'workout-emoji';
+                emoji.textContent = plan.emoji;
+
+                const titleText = document.createElement('div');
+                const name = document.createElement('div');
+                name.className = 'workout-name';
+                name.textContent = plan.title;
+
+                const desc = document.createElement('div');
+                desc.className = 'workout-description';
+                desc.textContent = plan.description;
+
+                titleText.append(name, desc);
+                title.append(emoji, titleText);
+
+                const button = document.createElement('button');
+                button.className = 'button button-small';
+                button.type = 'button';
+                button.textContent = 'Start Workout';
+                button.addEventListener('click', () => toggleWorkout(plan.id));
+
+                header.append(title, button);
+
+                const progressBar = document.createElement('div');
+                progressBar.className = 'progress-bar';
+                const progressFill = document.createElement('div');
+                progressFill.className = 'progress-fill';
+                progressFill.id = `progress-${plan.id}`;
+                progressFill.style.width = '0%';
+                progressBar.appendChild(progressFill);
+
+                const statusRow = document.createElement('div');
+                statusRow.style.marginTop = '0.5rem';
+                statusRow.style.color = '#6b7280';
+                statusRow.style.fontSize = '0.9rem';
+                statusRow.innerHTML = `
+                    <span id="completion-${plan.id}">0% Complete (0/0 exercises)</span>
+                    <span style="float: right; color: #2563eb; font-weight: bold;">
+                        <span id="xp-${plan.id}">0</span>/<span id="xp-target-${plan.id}">0</span> XP
+                    </span>
+                `;
+
+                const instructions = document.createElement('div');
+                instructions.className = 'workout-instructions';
+                const intro = document.createElement('p');
+                intro.innerHTML = `<strong>Instructions:</strong> ${plan.instructions.intro}`;
+                instructions.appendChild(intro);
+
+                const bulletList = document.createElement('ul');
+                plan.instructions.bullets.forEach(text => {
+                    const li = document.createElement('li');
+                    li.textContent = text;
+                    bulletList.appendChild(li);
+                });
+                instructions.appendChild(bulletList);
+
+                const exerciseList = document.createElement('div');
+                exerciseList.className = 'exercise-list';
+                exerciseList.id = `exercises-${plan.id}`;
+
+                plan.exercises.forEach((exercise, index) => {
+                    const item = document.createElement('div');
+                    item.className = 'exercise-item';
+                    item.dataset.index = index;
+                    item.addEventListener('click', () => toggleExercise(plan.id, index));
+
+                    const checkbox = document.createElement('div');
+                    checkbox.className = 'exercise-checkbox';
+                    checkbox.textContent = index + 1;
+
+                    const info = document.createElement('div');
+                    info.className = 'exercise-info';
+
+                    const exerciseName = document.createElement('div');
+                    exerciseName.className = 'exercise-name';
+                    exerciseName.textContent = exercise.name;
+
+                    const exerciseReps = document.createElement('div');
+                    exerciseReps.className = 'exercise-reps';
+                    exerciseReps.textContent = exercise.reps;
+
+                    info.append(exerciseName, exerciseReps);
+
+                    const xp = document.createElement('div');
+                    xp.className = 'exercise-xp';
+                    xp.textContent = `${exercise.xp} XP`;
+
+                    item.append(checkbox, info, xp);
+                    exerciseList.appendChild(item);
+                });
+
+                card.append(header, progressBar, statusRow, instructions, exerciseList);
+                container.appendChild(card);
+            });
+        }
         function initializeWorkoutMeta() {
+            workoutMeta = {};
             document.querySelectorAll('.workout-card').forEach(card => {
                 const day = card.dataset.day;
                 if (!day) {
@@ -1461,7 +845,6 @@
 
             return count;
         }
-
         function unlockAchievement(id, message, notify = false) {
             if (!ACHIEVEMENT_DETAILS[id]) {
                 return;
@@ -1573,7 +956,7 @@
                 if (Number.isNaN(position)) {
                     return;
                 }
-                const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item:nth-child(${position + 1})`);
+                const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item[data-index="${position}"]`);
                 if (!exerciseElement) {
                     return;
                 }
@@ -1597,18 +980,18 @@
                 addDayToLogs(day, dateKey);
             });
         }
-
         function resetForNewWeek(options = {}) {
             exerciseData = {};
             dayCompletion = {};
 
             if (options.resetUI) {
                 document.querySelectorAll('.exercise-list').forEach(list => {
-                    list.querySelectorAll('.exercise-item').forEach((item, index) => {
+                    list.querySelectorAll('.exercise-item').forEach(item => {
                         item.classList.remove('completed');
                         const checkbox = item.querySelector('.exercise-checkbox');
                         if (checkbox) {
-                            checkbox.textContent = index + 1;
+                            const index = parseInt(item.dataset.index, 10);
+                            checkbox.textContent = Number.isNaN(index) ? '' : index + 1;
                             checkbox.style.background = '#9ca3af';
                         }
                     });
@@ -1650,7 +1033,7 @@
             for (let i = 0; i < totalExercises; i++) {
                 if (exerciseData[`${day}-${i}`]) {
                     completed += 1;
-                    const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item:nth-child(${i + 1})`);
+                    const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item[data-index="${i}"]`);
                     if (exerciseElement) {
                         const xpElement = exerciseElement.querySelector('.exercise-xp');
                         const xpValue = xpElement ? parseInt(xpElement.textContent, 10) : 0;
@@ -1730,7 +1113,7 @@
 
         function toggleExercise(day, index) {
             const key = `${day}-${index}`;
-            const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item:nth-child(${index + 1})`);
+            const exerciseElement = document.querySelector(`#exercises-${day} .exercise-item[data-index="${index}"]`);
             if (!exerciseElement) {
                 return;
             }
@@ -1773,6 +1156,7 @@
         }
 
         document.addEventListener('DOMContentLoaded', function() {
+            renderWorkouts();
             initializeWorkoutMeta();
             loadData();
             restoreExerciseStates();
@@ -1780,6 +1164,5 @@
             refreshAppState();
         });
     </script>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style a reusable workout instructions callout for each training day
- add daily guidance and exercise lists for Wednesday through Sunday to complete the weekly schedule
- auto-refresh completion and XP targets from the new exercise data when workouts load

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d353abe1d8832b86f7faa0e21554c8